### PR TITLE
remove weird pseudo tabs (\t) and add a prerender flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ _Run this task with the `grunt htmlSnapshot` command._
                 //if you would rather not keep the script tags in the html snapshots
                 //set `removeScripts` to true. It's false by default
                 removeScripts: true,
-                //he goes the list of all urls that should be fetched
+		// allow to add a custom attribute to the body
+	        bodyAttr: 'data-prerendered',
+                //here goes the list of all urls that should be fetched
                 urls: [
                   '',
                   '#!/en-gb/showcase'

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -16,13 +16,14 @@ var sendMessage = function (arg) {
     fs.write(tmpfile, JSON.stringify(args) + "\n", "a");
 };
 
-var sanitizeHtml = function(html){
+var sanitizeHtml = function(html,options){
     //remove weird pseudo new lines
     html = html.replace(/\\n/g,"\n");
     // remove weird tabs
     html = html.replace(/\\t/g,"\t");
-    // add a pre-render data attribute
-    html = html.replace(/<body/,"<body data-prerendered='data-prerendered' ");
+    // add a custom attribute if so required
+    if (options.bodyAttr)
+        html = html.replace(/<body/,"<body " + options.bodyAttr + "='" + options.bodyAttr + "' ");
 
     //replace werid escaped quotes with real quotes
     html = html.replace(/\\"/g,'"');
@@ -64,7 +65,7 @@ page.open(url, function (status) {
             var html = page.evaluate(function () {
                 return  JSON.stringify(document.all[0].outerHTML);
             });
-            sendMessage("htmlSnapshot.pageReady", sanitizeHtml(html), url);
+            sendMessage("htmlSnapshot.pageReady", sanitizeHtml(html,options), url);
 
             phantom.exit();
         }, options.msWaitForPages);

--- a/tasks/htmlSnapshot.js
+++ b/tasks/htmlSnapshot.js
@@ -74,7 +74,8 @@ module.exports = function(grunt) {
                 // Additional PhantomJS options.
                 options: {
                     phantomScript: asset('phantomjs/bridge.js'),
-                    msWaitForPages: options.msWaitForPages
+                    msWaitForPages: options.msWaitForPages,
+                    bodyAttr: options.bodyAttr
                 },
                 // Complete the task when done.
                 done: function (err) {


### PR DESCRIPTION
1. There are weird pseudo tabs appearing (tested on Windows and Linux)
2. The snapshot file is output as one long line, adding true newlines
3. Also, adding a flag to the body could be useful for the app to know that
   this has been pre-rendered (for example, delaying re-loading of templates - see https://github.com/dai-shi/connect-prerenderer for an example)
