### PR TITLE
Add more replace functionality

### DIFF
--- a/tasks/htmlSnapshot.js
+++ b/tasks/htmlSnapshot.js
@@ -56,13 +56,6 @@ module.exports = function(grunt) {
                             sanitizeFilename(plainUrl) +
                             '.html';
 
-            options.replaceStrings.forEach(function(obj) {
-                var key = Object.keys(obj);
-                var value = obj[key];
-                var regex = new RegExp(key, 'g');
-                msg = msg.replace(regex, value);
-            });
-
             if (options.removeScripts){
                 msg = msg.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
             }
@@ -74,6 +67,13 @@ module.exports = function(grunt) {
             if (options.removeMetaTags) {
                 msg = msg.replace(/<meta\s.*?(\/)?>/gi, '');
             }
+
+            options.replaceStrings.forEach(function(obj) {
+                var key = Object.keys(obj);
+                var value = obj[key];
+                var regex = new RegExp(key, 'g');
+                msg = msg.replace(regex, value);
+            });
 
             grunt.file.write(fileName, msg);
             grunt.log.writeln(fileName, 'written');


### PR DESCRIPTION
For my personal use, I needed to generate a page for examples that I host on my site. However when making the new example folder with the necessary files, the assets would be pointing to the wrong path. `options.replaceStrings` to the rescue. The other two options were just for completeness since `removeScripts` was already there.

```
options: {
    // Remove link tags
    removeLinkTags: true,

    // Remove meta tags
    removeMetaTags: true,

    // Replace arbitrary parts of the html
    replaceStrings: [
        {'this': 'will get replaced by this'},
        {'/old/path/': '/new/path'}
    ]
}
```
