### PR TITLE
Jenkins can now fail a build when PhantomJS issues an error

### DIFF
--- a/tasks/htmlSnapshot.js
+++ b/tasks/htmlSnapshot.js
@@ -43,8 +43,8 @@ module.exports = function(grunt) {
         };
 
         phantom.on(taskChannelPrefix + ".error.onError", function (msg, trace) {
-            grunt.log.writeln('error: ' + msg);
             phantom.halt();
+            grunt.warn('error: ' + msg, 6);
         });
 
         phantom.on(taskChannelPrefix + ".console", function (msg, trace) {


### PR DESCRIPTION
`grunt.warn()` is now triggered with exit code 6 when a PhantomJS error is received. This should allow a CI platform such as Jenkins to correctly report a build failure in this scenario.
