### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ _Run this task with the `grunt htmlSnapshot` command._
                 //has a filename argument, must have a return that is a sanitized string
                 sanitize: function (requestUri) {
                     //returns 'index.html' if the url is '/', otherwise a prefix
-                    if (/\//.test(requestUri)) {
+                    if (/\/$/.test(requestUri)) {
                       return 'index.html';
                     } else {
                       return requestUri.replace(/\//g, 'prefix-');


### PR DESCRIPTION
The `/\//.test(requestUri)` matches more than just '/' route, added a `$` sign to mark the end of the string.
