### PR TITLE
Add haltOnError option

### DIFF
--- a/tasks/htmlSnapshot.js
+++ b/tasks/htmlSnapshot.js
@@ -30,7 +30,8 @@ module.exports = function(grunt) {
           removeScripts: false,
           removeLinkTags: false,
           removeMetaTags: false,
-          replaceStrings: []
+          replaceStrings: [],
+          haltOnError: true
         });
 
         // the channel prefix for this async grunt task
@@ -43,8 +44,12 @@ module.exports = function(grunt) {
         };
 
         phantom.on(taskChannelPrefix + ".error.onError", function (msg, trace) {
-            phantom.halt();
-            grunt.warn('error: ' + msg, 6);
+            if (options.haltOnError) {
+                phantom.halt();
+                grunt.warn('error: ' + msg, 6);
+            } else {
+                grunt.log.writeln(msg);
+            }
         });
 
         phantom.on(taskChannelPrefix + ".console", function (msg, trace) {


### PR DESCRIPTION
I'm working on a project where vendor code will output errors which are non-fatal to my app. This option lets me render templates even in the face of those errors, without breaking existing default functionality.
