### PR TITLE
Keep newlines in output html

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -20,8 +20,11 @@ var sendMessage = function (arg) {
 };
 
 var sanitizeHtml = function(html,options){
-    //remove weird pseudo new lines and tabs
-     html = html.replace(/\\n|\\t/g,"");
+    // unescape newlines
+    html = html.replace(/\\n/g,"\n");
+    // remove escaped tabs
+    html = html.replace(/\\t/g,"");
+
     // add a custom attribute if so required
     if (options.bodyAttr)
         html = html.replace(/<body/,"<body " + options.bodyAttr + "='" + options.bodyAttr + "' ");


### PR DESCRIPTION
Currently the sanitizeHtml method is removing escaped newlines and tabs.  This makes the output html appear in one single line and for diff purposes etc I'd like to be able to see the html tags formatting nicely.  

Instead of removing the newlines, this will just unescape them and leave the tab behavior as is.
