### PR TITLE
Added options for the page object of phantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,15 @@ _Run this task with the `grunt htmlSnapshot` command._
                 // a list of cookies to be put into the phantomjs cookies jar for the visited page
                 cookies: [
                   {"path": "/", "domain": "localhost", "name": "lang", "value": "en-gb"}
-                ]
+                ],
+				// options for phantomJs' page object
+				// see http://phantomjs.org/api/webpage/ for available options
+				pageOptions: {
+					viewportSize : {
+						width: 1200,
+						height: 800
+					}
+				}
               }
             }
         }

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -51,6 +51,13 @@ sendMessage("private", "version", phantom.version);
 // Create a new page.
 var page = require("webpage").create();
 
+// Add options to page object
+if (options.pageOptions) {
+    Object.keys(options.pageOptions).forEach(function (key) {
+       page[key] = options.pageOptions[key];
+    });
+}
+
 // Relay console logging messages.
 page.onConsoleMessage = function (message) {
     sendMessage("console", message);

--- a/tasks/htmlSnapshot.js
+++ b/tasks/htmlSnapshot.js
@@ -31,7 +31,8 @@ module.exports = function(grunt) {
           removeLinkTags: false,
           removeMetaTags: false,
           replaceStrings: [],
-          haltOnError: true
+          haltOnError: true,
+          pageOptions: {}
         });
 
         // the channel prefix for this async grunt task
@@ -104,7 +105,8 @@ module.exports = function(grunt) {
                     msWaitForPages: options.msWaitForPages,
                     bodyAttr: options.bodyAttr,
                     cookies: options.cookies,
-                    taskChannelPrefix: taskChannelPrefix
+                    taskChannelPrefix: taskChannelPrefix,
+                    pageOptions: options.pageOptions
                 },
                 // Complete the task when done.
                 done: function (err) {


### PR DESCRIPTION
The page object of phantomJS allows fine tuning of the browser. This is especially useful for setting the viewport size, the user agent, a name and a password for http authentication etc.

This commit will allow users to change the options of the page objects in the grunt options.
