### PR TITLE
Fixed "TypeError: 'undefined' is not a function refers to bind" error issue

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -71,6 +71,39 @@ page.onInitialized = function() {
     if (options.cookies) {
         setCookies(page, options.cookies);
     }
+
+    var bind,
+        slice = [].slice,
+        proto = Function.prototype,
+        featureMap;
+
+    featureMap = {
+        'function-bind': 'bind'
+    };
+
+    function has(feature) {
+        var prop = featureMap[feature];
+        return isFunction(proto[prop]);
+    }
+
+    // check for missing features
+    if (!has('function-bind')) {
+        // adapted from Mozilla Developer Network example at
+        // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/bind
+        bind = function bind(obj) {
+            var args = slice.call(arguments, 1),
+                self = this,
+                nop = function() {
+                },
+                bound = function() {
+                    return self.apply(this instanceof nop ? this : (obj || {}), args.concat(slice.call(arguments)));
+                };
+            nop.prototype = this.prototype || {}; // Firefox cries sometimes if prototype is undefined
+            bound.prototype = new nop();
+            return bound;
+        };
+        proto.bind = bind;
+    }
 }
 
 page.open(url, function (status) {

--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -83,7 +83,7 @@ page.onInitialized = function() {
 
     function has(feature) {
         var prop = featureMap[feature];
-        return isFunction(proto[prop]);
+        return (typeof proto[prop] === 'function');
     }
 
     // check for missing features


### PR DESCRIPTION
When I was ran `grunt htmlSnapshot`, I encountered this issue. After my investigation, I found it is caused by PhantomJS 1.x doesn't support `Function.prototype.bind`. 
For more about it, you can refer to 
https://github.com/macbre/phantomas/issues/491
